### PR TITLE
Use ro.rr.device to count users by device

### DIFF
--- a/src/android/romstats/Utilities.java
+++ b/src/android/romstats/Utilities.java
@@ -102,7 +102,7 @@ public class Utilities {
 	}
 
 	public static String getDevice() {
-		return SystemProperties.get("ro.product.model");
+		return SystemProperties.get("ro.rr.device");
 	}
 
 	public static String getModVersion() {


### PR DESCRIPTION
As many devices have more then one model or ro.product.model use ro.rr.device to get a unified count of how many users are running the OS on a device

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>